### PR TITLE
Fixed Spanish translation: an hour -> una hora

### DIFF
--- a/tasklist/es.json
+++ b/tasklist/es.json
@@ -474,7 +474,7 @@
       "s": "unos pocos segundos",
       "m": "un minuto",
       "mm": "%d minutos",
-      "h": "an hora",
+      "h": "una hora",
       "hh": "%d horas",
       "d": "un día",
       "dd": "%d días",


### PR DESCRIPTION
Hi, I'd like to propose a fix for the Spanish translation used for "an hour".
Thanks for your work!