### PR TITLE
Update pt-BR.json removing an extra comma

### DIFF
--- a/cockpit/pt-BR.json
+++ b/cockpit/pt-BR.json
@@ -2274,7 +2274,7 @@
     "TELEMETRY_FOOTER_LEARN_MORE": "Aprenda mais:",
     "TELEMETRY_FOOTER_PRIVACY_POLICY": "Política de Privacidade Camunda",
     "TELEMETRY_ERROR_STATUS": "Erro",
-    "TELEMETRY_ERROR_MESSAGE": "Sua configuração não pôde ser salva. Por favor, tente novamente.",
+    "TELEMETRY_ERROR_MESSAGE": "Sua configuração não pôde ser salva. Por favor, tente novamente."
   },
   "dateLocales": {
     "months": [


### PR DESCRIPTION
There was a comma in the last line of the labels "TELEMETRY_ERROR_MESSAGE".