### PR TITLE
fix(pt-BR): remove trailing commas

### DIFF
--- a/cockpit/pt-BR.json
+++ b/cockpit/pt-BR.json
@@ -2301,7 +2301,7 @@
     "TELEMETRY_SUCCESS_HEADING": "Sucesso",
     "TELEMETRY_SUCCESS": "A configuração da telemetria foi salva com sucesso",
     "TELEMETRY_ERROR_STATUS": "Erro",
-    "TELEMETRY_ERROR_MESSAGE": "Não foi possível salvar sua configuração. Por favor, tente novamente.",
+    "TELEMETRY_ERROR_MESSAGE": "Não foi possível salvar sua configuração. Por favor, tente novamente."
   },
   "dateLocales": {
     "months": [

--- a/tasklist/pt-BR.json
+++ b/tasklist/pt-BR.json
@@ -413,7 +413,7 @@
     "TELEMETRY_SUCCESS_HEADING": "Sucesso",
     "TELEMETRY_SUCCESS": "TA configuração da telemetria foi salva com sucesso",
     "TELEMETRY_ERROR_STATUS": "Erro",
-    "TELEMETRY_ERROR_MESSAGE": "Não foi possível salvar sua configuração. Por favor, tente novamente.",
+    "TELEMETRY_ERROR_MESSAGE": "Não foi possível salvar sua configuração. Por favor, tente novamente."
   },
   "dateLocales": {
     "months": [

--- a/welcome/pt-BR.json
+++ b/welcome/pt-BR.json
@@ -177,6 +177,6 @@
     "TELEMETRY_SUCCESS_HEADING": "Sucesso",
     "TELEMETRY_SUCCESS": "A configuração da telemetria foi salva com sucesso ",
     "TELEMETRY_ERROR_STATUS": "Erro",
-    "TELEMETRY_ERROR_MESSAGE": "Não foi possível salvar sua configuração. Por favor, tente novamente.",
+    "TELEMETRY_ERROR_MESSAGE": "Não foi possível salvar sua configuração. Por favor, tente novamente."
   }
 }


### PR DESCRIPTION
This PR removes trailing commas in the Brazilian Portuguese translation which were causing parsing errors.